### PR TITLE
Reduce required RFC sections to Summary/Details/Risks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ Cases where the RFC process need *not* be used:
    the following sections:
     * Summary
     * Details
-    * Advantages
-    * Disadvantages
+    * Risks
  - The proposal is discussed by the community and it is assumed that the
    proposal will change in accordance with that discussion.
  - In the case of no substantive disagreement the RFC is considered accepted


### PR DESCRIPTION
Advantages would tend to be obvious, as would Motivation as previously
required in the issue template. But thinking about the risks is useful,
and wouldn't naturally show up under summary or details.