### PR TITLE
RFC 17 - Code of Conduct

### DIFF
--- a/rfcs/code_of_conduct.md
+++ b/rfcs/code_of_conduct.md
@@ -1,0 +1,22 @@
+## RFC #17: Code of Conduct
+
+### Summary
+
+Introduce a code of conduct which clearly defines the acceptable behavior for
+all participants in the WPT project and includes contact information for a
+group of individuals who can be trusted to enforce the policy.
+
+### Details
+
+Publishing a code of conduct is a way "to be overt in our openness, welcoming
+all people to contribute, and pledging in return to value them as whole human
+beings and to foster an atmosphere of kindness, cooperation, and
+understanding." (via
+[contributor-covenant.org](https://www.contributor-covenant.org/)
+
+### Risks
+
+The burden of enforcement is not to be taken lightly. If a volunteer is unable
+to perform this service, then they will undermine the trust of the people the
+code is intended to help. We need to be certain that everyone who volunteers is
+prepared to enforce.


### PR DESCRIPTION
In [WPT issue gh-7520](https://github.com/web-platform-tests/wpt/pull/7520), @plehegar made an initial attemp to introduce a code of conduct based on the Rust language's policy. That seems like a good place to start from since it was only blocked on the existence of a group like the WPT Core Team. Should the code itself be included in this RFC?

One detail that needs to be decided is if the WPT Core Team is to be the same as the group of enforcers. Whatever the case, we should have some public commitment from each person who is listed in that document.

[Here's the rendered version.](https://github.com/bocoup/wpt-rfcs/blob/code-of-conduct/rfcs/code_of_conduct.md)