### PR TITLE
Add RFC numbers to RFC titles

### DIFF
--- a/rfcs/ahem_webfont.md
+++ b/rfcs/ahem_webfont.md
@@ -1,4 +1,4 @@
-# Load Ahem as a Webfont always
+# RFC 22: Load Ahem as a Webfont always
 
 ## Summary
 Make all tests load the Ahem font as a webfont instead of expecting Ahem to be

--- a/rfcs/assert_throws.md
+++ b/rfcs/assert_throws.md
@@ -1,4 +1,4 @@
-# `testharness.js`: Replace `assert_throws` and `promise_rejects` with more fine-grained APIs
+# RFC 29: `testharness.js`: Replace `assert_throws` and `promise_rejects` with more fine-grained APIs
 
 ## Summary
 

--- a/rfcs/manifest-working-copy.md
+++ b/rfcs/manifest-working-copy.md
@@ -1,4 +1,4 @@
-# Always use the working copy for the manifest
+# RFC 19: Always use the working copy for the manifest
 
 ## Summary
 

--- a/rfcs/remove_stub.md
+++ b/rfcs/remove_stub.md
@@ -1,4 +1,4 @@
-# Remove support for stub-* files in the manifest
+# RFC 27: Remove support for stub-* files in the manifest
 
 ## Summary
 Any files named stub-* are currently treated as "stub" in the manifest. Remove support for this.

--- a/rfcs/single_test.md
+++ b/rfcs/single_test.md
@@ -1,4 +1,4 @@
-# RFC: `setup({single_test: true})` opt-in
+# RFC 28: `setup({single_test: true})` opt-in
 
 ## Summary
 


### PR DESCRIPTION
This requirement is defined in the project README file:

> Each RFC requires a PR in this repository consisting of a single
> markdown file added to the `rfcs` directory setting out the proposed
> change. This file must have the PR number as the title and at least
> the following sections:

Update the RFCs which omit their number.