### PR TITLE
RFC #163: Add web_feature metadata file to web-platform-tests

### DIFF
--- a/rfcs/feature-set-metadata-file-to-web-platform-tests.md
+++ b/rfcs/feature-set-metadata-file-to-web-platform-tests.md
@@ -1,0 +1,221 @@
+# RFC #: Add feature_set metadata file to web-platform-tests
+
+Author: @jcscottiii
+
+# Introduction
+
+The web-platform-tests (WPT) project is a valuable resource for testing web
+platform features and contains valuable metadata such as feature specs.
+Recently, the [WebDX Community Group](https://www.w3.org/community/webdx/)
+began creating the [feature-set](https://github.com/web-platform-dx/feature-set)
+repository. That repository serves as a basic shared catalog of feature
+definitions of the web platform. Feature-set itself doesn't intend to produce
+data but rather link to existing data that will inform audiences which features
+are part of [Baseline](https://web.dev/baseline/). However, there's a great
+opportunity to connect the WPT ecosystem to the feature-set catalog. By doing
+this, it would enable users of wpt.fyi to filter by feature-set grouping, which
+is similar to
+[the ability to filter by spec](https://github.com/web-platform-tests/wpt.fyi/issues/1489).
+The RFC proposes the addition of a FEATURE_SET.yml metadata file which would
+enable the linkage between WPT and feature-set.
+
+# Proposed change
+
+The proposed change includes:
+
+1. Introduce a new metadata file, FEATURE_SET.yml
+2. Adjust the wpt-pr-bot to handle reviews of the changes
+3. Create a script to generate a manifest
+
+Below are the details for each step.
+
+## Step 1. Introduce a new metadata file, FEATURE_SET.yml
+
+Originally, there was a RFC that proposed adding these details to the existing
+META.yml. During the August 01, 2023 Monthly WPT
+[Meeting](https://github.com/web-platform-tests/wpt-notes/blob/master/minutes/2023-08-01.md#rfc-157---add-feature-meta-tag-to-web-platform-tests-meta-data),
+it was discussed that it should be a separate file. This section describes the structure of the file.
+
+This file is expected to be in the same places developers would expect a META.yml.
+
+### File examples
+
+```
+parser_version: v1
+apply_mode: RECURSIVE
+feature_set: subgrid
+overrides:
+- file_name: name.txt
+  feature_set: feature2
+```
+
+### Schema
+
+```json
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/Main",
+    "definitions": {
+        "Main": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "parser_version": {
+                    "type": "string",
+                    "description": "version of the parser"
+                },
+                "feature_set": {
+                    "type": "string",
+                    "description": "The feature set key"
+                },
+                "apply_mode": {
+                    "type": "string",
+                    "anyOf": [
+                    	{
+                            "const": "DEFAULT",
+                            "description": "Applies recursively until the presence of another FEATURE_SET.yml in a subdirectory."
+                        },
+                    	{
+                            "const": "FORCE_RECURSIVE",
+                            "description": "Applies recursively throughout the all sub-directories. Useful if feature_set hierarchy exactly matches wpt directory structure."
+                        }
+                    ],
+                    "default": "DEFAULT"
+                },
+                "overrides": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Override"
+                    }
+                }
+            },
+            "required": [
+                "feature_set",
+                "parser_version",
+                "apply_mode"
+            ],
+            "title": "Main"
+        },
+        "Override": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "file_name": {
+                    "type": "string",
+                    "description": " The file name of the test in the same directory as this file."
+                },
+                "feature_set": {
+                    "type": "string",
+                    "description": "The feature set key"
+                },
+                "override_mode": {
+                    "type": "string",
+                    "anyOf": [
+                    	{
+                            "const": "APPEND",
+                            "description": "Append to the current feature_set key(s) for the given file"
+                        },
+                    	{
+                            "const": "REPLACE",
+                            "description": "Replace the current feature_set key(s) for the given file"
+                        },
+                    ],
+                    "default": "APPEND"
+                },
+            },
+            "required": [
+                "feature_set",
+                "file_name"
+            ],
+            "title": "Override"
+        }
+    }
+}
+```
+
+The next section describes the manifest generation process section.
+
+## Step 2. Create a script to generate a manifest
+
+A command will be created in the `tools/manifest` folder to generate the
+FEATURE_SET_MANIFEST.json file. While it is in that folder, its logic will
+be independent of the existing manifest logic. (As discussed in the August 01,
+2023 Monthly WPT
+[Meeting](https://github.com/web-platform-tests/wpt-notes/blob/master/minutes/2023-08-01.md#rfc-157---add-feature-meta-tag-to-web-platform-tests-meta-data),
+it should not use the same logic.) The only thing it will it
+do is generate data in the same structure.
+
+By using the same format, wpt.fyi can use it to allow filtering by feature set.
+
+The rules of the generation are described in the file schema above by the
+directory level `apply_mode` flag and the per file `override_mode`.
+
+## Step 3. Adjust the wpt-pr-bot to handle reviews of the changes
+
+### Current State of wpt-pr-bot
+
+Currently, the wpt-pr-bot builds a list of PR reviewers by:
+1. Retrieving the paths for all of the files
+2. Finding the nearest META.yml file for each path
+3. Add the list of suggested_reviewers from a given META.yml to a set of
+   reviewers
+
+### Proposed changes
+
+Have the wpt-pr-bot filter the FEATURE_SET.yml file changes to only request
+reviews from feature-set contributors.
+
+This will reduce the amount of unneeded reviews from non feature-set contributors.
+
+---
+
+# Risks
+
+As a result of putting all the information in FEATURE_SET.yml, the overrides
+which are linked to the file can go out of sync as test files are moved,
+renamed, or deleted.
+
+## Short Term Mitigation
+
+While desired, there is no anticipated percentage of tests that will use the
+override functionality. As a result, an outside process could alert when there
+is some issue with the data. The feature set team will be responsible for that.
+
+If it becomes a problem to manage, one of the following future mitigation options
+in the next section can solve it.
+
+## Future Mitigation
+
+This RFC does not cover the a long term mitigation plan for the risk. However,
+a possible mitigation could be one of the following:
+- A new GitHub Action that can prevent a PR from being merged if a user
+  modifies a overridden test without modifying the FEATURE_SET.yml, or
+- Expand on the wpt-pr-bot changes to require a FEATURE_SET reviewer if it
+  detects a overridden test has changed (even if FEATURE_SET.yml has not).
+
+# Other Notes
+
+## Changes for WPT Contributors
+
+The metadata tag is not mandatory. WPT contributions will not be blocked if
+contributors do not add the metadata tag to the FEATURE_SET.yml files or test files.
+
+## Populating and maintaining the metadata files
+
+As the [feature-set](https://github.com/web-platform-dx/feature-set) repository
+is populated with feature-set definitions, feature-set contributors will begin
+populating the metadata in WPT.
+
+In regards to maintaining the metadata files, feature-set contributors will be
+responsible for the mitigation options
+described above. 
+# Roll back of this RFC
+
+The following steps will allow the community to roll back this RFC in the event it is deemed unnecessary:
+
+1. Remove all the new metadata files
+  - ```sh
+    find . -name FEATURE_SET.yml -type f -delete
+    ```
+2. Remove the new feature_set.py and reference in commands.json
+  - This will likely happen by reverting the PRs in the tools/manifest folder.

--- a/rfcs/feature-set-metadata-file-to-web-platform-tests.md
+++ b/rfcs/feature-set-metadata-file-to-web-platform-tests.md
@@ -1,4 +1,4 @@
-# RFC #: Add feature_set metadata file to web-platform-tests
+# RFC #163: Add feature_set metadata file to web-platform-tests
 
 Author: @jcscottiii
 

--- a/rfcs/feature-set-metadata-file-to-web-platform-tests.md
+++ b/rfcs/feature-set-metadata-file-to-web-platform-tests.md
@@ -24,8 +24,9 @@ enable the linkage between WPT and web-features.
 The proposed change includes:
 
 1. Introduce a new metadata file, WEB_FEATURE.yml
-2. Create a script to generate a manifest
-3. Adjust the wpt-pr-bot to handle reviews of the changes
+2. Add linting functionality
+3. Create a script to generate a manifest
+4. Adjust the wpt-pr-bot to handle reviews of the changes
 
 Below are the details for each step.
 
@@ -135,9 +136,16 @@ overrides:
 }
 ```
 
-The next section describes the manifest generation process section.
+## Step 2. Add linting functionality
 
-## Step 2. Create a script to generate a manifest
+There exists a potential risk of putting all the information in WEB_FEATURE.yml:
+the overrides which are linked to the file can go out of sync as test files are moved,
+renamed, or deleted.
+
+As a result, this RFC also proposes a lint command to detect this. The code for
+this will reside in `tools/lint/lint.py`.
+
+## Step 3. Create a script to generate a manifest
 
 A command will be created in the `tools/manifest` folder to generate the
 WEB_FEATURE_MANIFEST.json file. While it is in that folder, its logic will
@@ -152,7 +160,7 @@ By using the same format, wpt.fyi can use it to allow filtering by web feature.
 The rules of the generation are described in the file schema above by the
 directory level `apply_mode` flag and the per file `override_mode`.
 
-## Step 3. Adjust the wpt-pr-bot to handle reviews of the changes
+## Step 4. Adjust the wpt-pr-bot to handle reviews of the changes
 
 ### Current State of wpt-pr-bot
 
@@ -173,27 +181,14 @@ This will reduce the amount of unneeded reviews from non web-features contributo
 
 # Risks
 
-As a result of putting all the information in WEB_FEATURE.yml, the overrides
-which are linked to the file can go out of sync as test files are moved,
-renamed, or deleted.
+A set of new linting cases (mentioned in Step 2.) could confuse existing
+developers.
 
-## Short Term Mitigation
+## Mitigation
 
-While desired, there is no anticipated percentage of tests that will use the
-override functionality. As a result, an outside process could alert when there
-is some issue with the data. The web feature team will be responsible for that.
-
-If it becomes a problem to manage, one of the following future mitigation options
-in the next section can solve it.
-
-## Future Mitigation
-
-This RFC does not cover the a long term mitigation plan for the risk. However,
-a possible mitigation could be one of the following:
-- A new GitHub Action that can prevent a PR from being merged if a user
-  modifies a overridden test without modifying the WEB_FEATURE.yml, or
-- Expand on the wpt-pr-bot changes to require a WEB_FEATURE reviewer if it
-  detects a overridden test has changed (even if WEB_FEATURE.yml has not).
+Ways to mitigate this include:
+- Informative logging
+- Additional documentation to describe why this linting exists.
 
 # Other Notes
 
@@ -221,3 +216,5 @@ The following steps will allow the community to roll back this RFC in the event 
     ```
 2. Remove the new web_feature.py and reference in commands.json
   - This will likely happen by reverting the PRs in the tools/manifest folder.
+3. Remove the lint code in tools/lint/lint.py.
+    - This will likely happen by reverting the PRs in the tools/lint/lint.py file.

--- a/rfcs/feature-set-metadata-file-to-web-platform-tests.md
+++ b/rfcs/feature-set-metadata-file-to-web-platform-tests.md
@@ -1,4 +1,4 @@
-# RFC #163: Add feature_set metadata file to web-platform-tests
+# RFC #163: Add web_feature metadata file to web-platform-tests
 
 Author: @jcscottiii
 
@@ -16,20 +16,20 @@ opportunity to connect the WPT ecosystem to the feature-set catalog. By doing
 this, it would enable users of wpt.fyi to filter by feature-set grouping, which
 is similar to
 [the ability to filter by spec links](https://github.com/web-platform-tests/wpt.fyi/issues/1489).
-The RFC proposes the addition of a FEATURE_SET.yml metadata file which would
+The RFC proposes the addition of a WEB_FEATURE.yml metadata file which would
 enable the linkage between WPT and feature-set.
 
 # Proposed change
 
 The proposed change includes:
 
-1. Introduce a new metadata file, FEATURE_SET.yml
+1. Introduce a new metadata file, WEB_FEATURE.yml
 2. Create a script to generate a manifest
 3. Adjust the wpt-pr-bot to handle reviews of the changes
 
 Below are the details for each step.
 
-## Step 1. Introduce a new metadata file, FEATURE_SET.yml
+## Step 1. Introduce a new metadata file, WEB_FEATURE.yml
 
 Originally, there was a RFC that proposed adding these details to the existing
 META.yml. During the August 01, 2023 Monthly WPT
@@ -43,17 +43,17 @@ This file is expected to be in the same places developers would expect a META.ym
 Typical example:
 
 ```
-feature_set: subgrid
+web_feature: subgrid
 ```
 
 An example using all of the fields:
 
 ```
 apply_mode: FORCE_RECURSIVE
-feature_set: feature1
+web_feature: feature1
 overrides:
 - file_name: name.txt
-  feature_set: feature2
+  web_feature: feature2
   override_mode: REPLACE
 ```
 
@@ -68,20 +68,20 @@ overrides:
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "feature_set": {
+                "web_feature": {
                     "type": "string",
-                    "description": "The feature set key"
+                    "description": "The web feature key"
                 },
                 "apply_mode": {
                     "type": "string",
                     "anyOf": [
                     	{
                             "const": "DEFAULT",
-                            "description": "Applies recursively until the presence of another FEATURE_SET.yml in a subdirectory."
+                            "description": "Applies recursively until the presence of another WEB_FEATURE.yml in a subdirectory."
                         },
                     	{
                             "const": "FORCE_RECURSIVE",
-                            "description": "Applies recursively throughout the all sub-directories. Useful if feature_set hierarchy exactly matches wpt directory structure."
+                            "description": "Applies recursively throughout the all sub-directories. Useful if web_feature hierarchy exactly matches wpt directory structure."
                         }
                     ],
                     "default": "DEFAULT"
@@ -94,7 +94,7 @@ overrides:
                 }
             },
             "required": [
-                "feature_set"
+                "web_feature"
             ],
             "title": "Main"
         },
@@ -106,27 +106,27 @@ overrides:
                     "type": "string",
                     "description": " The file name of the test in the same directory as this file."
                 },
-                "feature_set": {
+                "web_feature": {
                     "type": "string",
-                    "description": "The feature set key"
+                    "description": "The web feature key"
                 },
                 "override_mode": {
                     "type": "string",
                     "anyOf": [
                     	{
                             "const": "APPEND",
-                            "description": "Append to the current feature_set key(s) for the given file"
+                            "description": "Append to the current web_feature key(s) for the given file"
                         },
                     	{
                             "const": "REPLACE",
-                            "description": "Replace the current feature_set key(s) for the given file"
+                            "description": "Replace the current web_feature key(s) for the given file"
                         },
                     ],
                     "default": "APPEND"
                 },
             },
             "required": [
-                "feature_set",
+                "web_feature",
                 "file_name"
             ],
             "title": "Override"
@@ -140,14 +140,14 @@ The next section describes the manifest generation process section.
 ## Step 2. Create a script to generate a manifest
 
 A command will be created in the `tools/manifest` folder to generate the
-FEATURE_SET_MANIFEST.json file. While it is in that folder, its logic will
+WEB_FEATURE_MANIFEST.json file. While it is in that folder, its logic will
 be independent of the existing manifest logic. (As discussed in the August 01,
 2023 Monthly WPT
 [Meeting](https://github.com/web-platform-tests/wpt-notes/blob/master/minutes/2023-08-01.md#rfc-157---add-feature-meta-tag-to-web-platform-tests-meta-data),
 it should not use the same logic.) The only thing it will it
 do is generate data in the same structure.
 
-By using the same format, wpt.fyi can use it to allow filtering by feature set.
+By using the same format, wpt.fyi can use it to allow filtering by web feature.
 
 The rules of the generation are described in the file schema above by the
 directory level `apply_mode` flag and the per file `override_mode`.
@@ -164,7 +164,7 @@ Currently, the wpt-pr-bot builds a list of PR reviewers by:
 
 ### Proposed changes
 
-Have the wpt-pr-bot filter the FEATURE_SET.yml file changes to only request
+Have the wpt-pr-bot filter the WEB_FEATURE.yml file changes to only request
 reviews from feature-set contributors.
 
 This will reduce the amount of unneeded reviews from non feature-set contributors.
@@ -173,7 +173,7 @@ This will reduce the amount of unneeded reviews from non feature-set contributor
 
 # Risks
 
-As a result of putting all the information in FEATURE_SET.yml, the overrides
+As a result of putting all the information in WEB_FEATURE.yml, the overrides
 which are linked to the file can go out of sync as test files are moved,
 renamed, or deleted.
 
@@ -181,7 +181,7 @@ renamed, or deleted.
 
 While desired, there is no anticipated percentage of tests that will use the
 override functionality. As a result, an outside process could alert when there
-is some issue with the data. The feature set team will be responsible for that.
+is some issue with the data. The web feature team will be responsible for that.
 
 If it becomes a problem to manage, one of the following future mitigation options
 in the next section can solve it.
@@ -191,16 +191,16 @@ in the next section can solve it.
 This RFC does not cover the a long term mitigation plan for the risk. However,
 a possible mitigation could be one of the following:
 - A new GitHub Action that can prevent a PR from being merged if a user
-  modifies a overridden test without modifying the FEATURE_SET.yml, or
-- Expand on the wpt-pr-bot changes to require a FEATURE_SET reviewer if it
-  detects a overridden test has changed (even if FEATURE_SET.yml has not).
+  modifies a overridden test without modifying the WEB_FEATURE.yml, or
+- Expand on the wpt-pr-bot changes to require a WEB_FEATURE reviewer if it
+  detects a overridden test has changed (even if WEB_FEATURE.yml has not).
 
 # Other Notes
 
 ## Changes for WPT Contributors
 
 The metadata tag is not mandatory. WPT contributions will not be blocked if
-contributors do not add the metadata tag to the FEATURE_SET.yml files or test files.
+contributors do not add the metadata tag to the WEB_FEATURE.yml files or test files.
 
 ## Populating and maintaining the metadata files
 
@@ -217,7 +217,7 @@ The following steps will allow the community to roll back this RFC in the event 
 
 1. Remove all the new metadata files
   - ```sh
-    find . -name FEATURE_SET.yml -type f -delete
+    find . -name WEB_FEATURE.yml -type f -delete
     ```
-2. Remove the new feature_set.py and reference in commands.json
+2. Remove the new web_feature.py and reference in commands.json
   - This will likely happen by reverting the PRs in the tools/manifest folder.

--- a/rfcs/feature-set-metadata-file-to-web-platform-tests.md
+++ b/rfcs/feature-set-metadata-file-to-web-platform-tests.md
@@ -1,4 +1,4 @@
-# RFC #163: Add web_feature metadata file to web-platform-tests
+# RFC #163: Add web_features metadata file to web-platform-tests
 
 Author: @jcscottiii
 
@@ -16,21 +16,21 @@ opportunity to connect the WPT ecosystem to the web-features catalog. By doing
 this, it would enable users of wpt.fyi to filter by web-features grouping, which
 is similar to
 [the ability to filter by spec links](https://github.com/web-platform-tests/wpt.fyi/issues/1489).
-The RFC proposes the addition of a WEB_FEATURE.yml metadata file which would
+The RFC proposes the addition of a WEB_FEATURES.yml metadata file which would
 enable the linkage between WPT and web-features.
 
 # Proposed change
 
 The proposed change includes:
 
-1. Introduce a new metadata file, WEB_FEATURE.yml
+1. Introduce a new metadata file, WEB_FEATURES.yml
 2. Add linting functionality
 3. Create a script to generate a manifest
 4. Adjust the wpt-pr-bot to handle reviews of the changes
 
 Below are the details for each step.
 
-## Step 1. Introduce a new metadata file, WEB_FEATURE.yml
+## Step 1. Introduce a new metadata file, WEB_FEATURES.yml
 
 Originally, there was a RFC that proposed adding these details to the existing
 META.yml. During the August 01, 2023 Monthly WPT
@@ -162,7 +162,7 @@ features:
 
 ## Step 2. Add linting functionality
 
-There exists a potential risk of putting all the information in WEB_FEATURE.yml:
+There exists a potential risk of putting all the information in WEB_FEATURES.yml:
 the overrides which are linked to the file can go out of sync as test files are moved,
 renamed, or deleted.
 
@@ -172,7 +172,7 @@ this will reside in `tools/lint/lint.py`.
 ## Step 3. Create a script to generate a manifest
 
 A command will be created in the `tools/manifest` folder to generate the
-WEB_FEATURE_MANIFEST.json file. While it is in that folder, its logic will
+WEB_FEATURES_MANIFEST.json file. While it is in that folder, its logic will
 be independent of the existing manifest logic. (As discussed in the August 01,
 2023 Monthly WPT
 [Meeting](https://github.com/web-platform-tests/wpt-notes/blob/master/minutes/2023-08-01.md#rfc-157---add-feature-meta-tag-to-web-platform-tests-meta-data),
@@ -196,7 +196,7 @@ Currently, the wpt-pr-bot builds a list of PR reviewers by:
 
 ### Proposed changes
 
-Have the wpt-pr-bot filter the WEB_FEATURE.yml file changes to only request
+Have the wpt-pr-bot filter the WEB_FEATURES.yml file changes to only request
 reviews from web-features contributors.
 
 This will reduce the amount of unneeded reviews from non web-features contributors.
@@ -219,7 +219,7 @@ Ways to mitigate this include:
 ## Changes for WPT Contributors
 
 The metadata tag is not mandatory. WPT contributions will not be blocked if
-contributors do not add the metadata tag to the WEB_FEATURE.yml files or test files.
+contributors do not add the metadata tag to the WEB_FEATURES.yml files or test files.
 
 ## Populating and maintaining the metadata files
 
@@ -236,9 +236,9 @@ The following steps will allow the community to roll back this RFC in the event 
 
 1. Remove all the new metadata files
     - ```sh
-        find . -name WEB_FEATURE.yml -type f -delete
+        find . -name WEB_FEATURES.yml -type f -delete
         ```
-2. Remove the new web_feature.py and reference in commands.json
+2. Remove the new web_features.py and reference in commands.json
     - This will likely happen by reverting the PRs in the tools/manifest folder.
 3. Remove the lint code in tools/lint/lint.py.
     - This will likely happen by reverting the PRs in the tools/lint/lint.py file.

--- a/rfcs/feature-set-metadata-file-to-web-platform-tests.md
+++ b/rfcs/feature-set-metadata-file-to-web-platform-tests.md
@@ -24,8 +24,8 @@ enable the linkage between WPT and feature-set.
 The proposed change includes:
 
 1. Introduce a new metadata file, FEATURE_SET.yml
-2. Adjust the wpt-pr-bot to handle reviews of the changes
-3. Create a script to generate a manifest
+2. Create a script to generate a manifest
+3. Adjust the wpt-pr-bot to handle reviews of the changes
 
 Below are the details for each step.
 
@@ -40,13 +40,22 @@ This file is expected to be in the same places developers would expect a META.ym
 
 ### File examples
 
+Typical example:
+
 ```
 parser_version: v1
-apply_mode: RECURSIVE
 feature_set: subgrid
+```
+
+An example using all of the fields
+```
+parser_version: v1
+apply_mode: FORCE_RECURSIVE
+feature_set: feature1
 overrides:
 - file_name: name.txt
   feature_set: feature2
+  override_mode: REPLACE
 ```
 
 ### Schema
@@ -92,7 +101,6 @@ overrides:
             "required": [
                 "feature_set",
                 "parser_version",
-                "apply_mode"
             ],
             "title": "Main"
         },

--- a/rfcs/feature-set-metadata-file-to-web-platform-tests.md
+++ b/rfcs/feature-set-metadata-file-to-web-platform-tests.md
@@ -43,13 +43,12 @@ This file is expected to be in the same places developers would expect a META.ym
 Typical example:
 
 ```
-parser_version: v1
 feature_set: subgrid
 ```
 
-An example using all of the fields
+An example using all of the fields:
+
 ```
-parser_version: v1
 apply_mode: FORCE_RECURSIVE
 feature_set: feature1
 overrides:
@@ -69,10 +68,6 @@ overrides:
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "parser_version": {
-                    "type": "string",
-                    "description": "version of the parser"
-                },
                 "feature_set": {
                     "type": "string",
                     "description": "The feature set key"
@@ -99,8 +94,7 @@ overrides:
                 }
             },
             "required": [
-                "feature_set",
-                "parser_version",
+                "feature_set"
             ],
             "title": "Main"
         },

--- a/rfcs/feature-set-metadata-file-to-web-platform-tests.md
+++ b/rfcs/feature-set-metadata-file-to-web-platform-tests.md
@@ -7,17 +7,17 @@ Author: @jcscottiii
 The web-platform-tests (WPT) project is a valuable resource for testing web
 platform features and contains valuable metadata such as feature spec links.
 Recently, the [WebDX Community Group](https://www.w3.org/community/webdx/)
-began creating the [feature-set](https://github.com/web-platform-dx/feature-set)
+began creating the [web-features](https://github.com/web-platform-dx/web-features)
 repository. That repository serves as a basic shared catalog of feature
-definitions of the web platform. Feature-set itself doesn't intend to produce
+definitions of the web platform. The repository itself doesn't intend to produce
 data but rather link to existing data that will inform audiences which features
 are part of [Baseline](https://web.dev/baseline/). However, there's a great
-opportunity to connect the WPT ecosystem to the feature-set catalog. By doing
-this, it would enable users of wpt.fyi to filter by feature-set grouping, which
+opportunity to connect the WPT ecosystem to the web-features catalog. By doing
+this, it would enable users of wpt.fyi to filter by web-features grouping, which
 is similar to
 [the ability to filter by spec links](https://github.com/web-platform-tests/wpt.fyi/issues/1489).
 The RFC proposes the addition of a WEB_FEATURE.yml metadata file which would
-enable the linkage between WPT and feature-set.
+enable the linkage between WPT and web-features.
 
 # Proposed change
 
@@ -165,9 +165,9 @@ Currently, the wpt-pr-bot builds a list of PR reviewers by:
 ### Proposed changes
 
 Have the wpt-pr-bot filter the WEB_FEATURE.yml file changes to only request
-reviews from feature-set contributors.
+reviews from web-features contributors.
 
-This will reduce the amount of unneeded reviews from non feature-set contributors.
+This will reduce the amount of unneeded reviews from non web-features contributors.
 
 ---
 
@@ -204,11 +204,11 @@ contributors do not add the metadata tag to the WEB_FEATURE.yml files or test fi
 
 ## Populating and maintaining the metadata files
 
-As the [feature-set](https://github.com/web-platform-dx/feature-set) repository
-is populated with feature-set definitions, feature-set contributors will begin
+As the [web-features](https://github.com/web-platform-dx/web-features) repository
+is populated with web-features definitions, web-features contributors will begin
 populating the metadata in WPT.
 
-In regards to maintaining the metadata files, feature-set contributors will be
+In regards to maintaining the metadata files, web-features contributors will be
 responsible for the mitigation options
 described above. 
 # Roll back of this RFC

--- a/rfcs/feature-set-metadata-file-to-web-platform-tests.md
+++ b/rfcs/feature-set-metadata-file-to-web-platform-tests.md
@@ -5,7 +5,7 @@ Author: @jcscottiii
 # Introduction
 
 The web-platform-tests (WPT) project is a valuable resource for testing web
-platform features and contains valuable metadata such as feature specs.
+platform features and contains valuable metadata such as feature spec links.
 Recently, the [WebDX Community Group](https://www.w3.org/community/webdx/)
 began creating the [feature-set](https://github.com/web-platform-dx/feature-set)
 repository. That repository serves as a basic shared catalog of feature
@@ -15,7 +15,7 @@ are part of [Baseline](https://web.dev/baseline/). However, there's a great
 opportunity to connect the WPT ecosystem to the feature-set catalog. By doing
 this, it would enable users of wpt.fyi to filter by feature-set grouping, which
 is similar to
-[the ability to filter by spec](https://github.com/web-platform-tests/wpt.fyi/issues/1489).
+[the ability to filter by spec links](https://github.com/web-platform-tests/wpt.fyi/issues/1489).
 The RFC proposes the addition of a FEATURE_SET.yml metadata file which would
 enable the linkage between WPT and feature-set.
 


### PR DESCRIPTION
Replacement of https://github.com/web-platform-tests/rfcs/pull/157 that uses the feedback from the last WPT [meeting](https://github.com/web-platform-tests/wpt-notes/blob/master/minutes/2023-08-01.md#rfc-157---add-feature-meta-tag-to-web-platform-tests-meta-data).

[Rendered](https://github.com/web-platform-tests/rfcs/blob/Add-feature_set-metadata-file-to-web-platform-tests/rfcs/feature-set-metadata-file-to-web-platform-tests.md)