### PR TITLE
Clarify details around review approvals before merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Cases where the RFC process need *not* be used:
  - The proposal is discussed by the community and it is assumed that the
    proposal will change in accordance with that discussion.
  - At least one review approval is required to merge a PR. For changes that
-   may impact downstream WPT consumers more approvals should be sought, or at
-   least a clear acknowledgement from those consumers that this change can be
+   may impact downstream WPT consumers there is an additional requirement
+   of agreement from those consumers that the proposed change can be
    accommodated in their workflows.
  - Anyone is welcome to add the PR to the monthly
    [WPT infra meeting](https://github.com/web-platform-tests/wpt-notes) to

--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ Cases where the RFC process need *not* be used:
    ensure it gets discussed.
  - After review approval(s) and in the case of no substantive disagreement, the
    RFC is considered accepted 1 week after the first approval. If any participant
-   requests it, the comment period is extended to 2 weeks.
+   requests it, more time can be granted to review the proposal. This will not be
+   less than one week but may be longer (e.g. until the next WPT infra meeting).
+   However if no feedback is forthcoming by the agreed date, the proposal may
+   be considered accepted.
  - If substantive disagreement remains, then the issue is escalated to the
    [core team](https://github.com/orgs/web-platform-tests/teams/wpt-core-team/)
    for a decision:

--- a/README.md
+++ b/README.md
@@ -41,8 +41,14 @@ Cases where the RFC process need *not* be used:
    may impact downstream WPT consumers more approvals should be sought, or at
    least a clear acknowledgement from those consumers that this change can be
    accommodated in their workflows.
+ - Anyone is welcome to add the PR to the monthly
+   [WPT infra meeting](https://github.com/web-platform-tests/wpt-notes) to
+   have a dsicsussion about it. To add an RFC to the agenda, tag the PR with the
+   `agenda+` label.
  - If reviewers or downstream consumers are not responsive after at least two
-   weeks, the PR should be added to the monthly [WPT infra meeting](https://github.com/web-platform-tests/wpt-notes) to ensure it gets discussed. Anyone is welcome to file issues in that repo to request the discussion of an RFC.
+   weeks, the PR should be added to the monthly
+   [WPT infra meeting](https://github.com/web-platform-tests/wpt-notes) to
+   ensure it gets discussed.
  - After review approval(s) and in the case of no substantive disagreement, the
    RFC is considered accepted 1 week after the first approval. If any participant
    requests it, the comment period is extended to 2 weeks.

--- a/README.md
+++ b/README.md
@@ -37,9 +37,15 @@ Cases where the RFC process need *not* be used:
     * Risks
  - The proposal is discussed by the community and it is assumed that the
    proposal will change in accordance with that discussion.
- - In the case of no substantive disagreement the RFC is considered accepted
-   after 1 week. If any participant requests it, the comment period is extended
-   to 2 weeks.
+ - At least one review approval is required to merge a PR. For changes that
+   may impact downstream WPT consumers more approvals should be sought, or at
+   least a clear acknowledgement from those consumers that this change can be
+   accommodated in their workflows.
+ - If reviewers or downstream consumers are not responsive after at least two
+   weeks, the PR should be added to the monthly [WPT infra meeting](https://github.com/web-platform-tests/wpt-notes) to ensure it gets discussed. Anyone is welcome to file issues in that repo to request the discussion of an RFC.
+ - After review approval(s) and in the case of no substantive disagreement, the
+   RFC is considered accepted 1 week after the first approval. If any participant
+   requests it, the comment period is extended to 2 weeks.
  - If substantive disagreement remains, then the issue is escalated to the
    [core team](https://github.com/orgs/web-platform-tests/teams/wpt-core-team/)
    for a decision:


### PR DESCRIPTION
This captures my understanding of the meeting consensus after today's [discussion](https://github.com/web-platform-tests/wpt-notes/blob/master/minutes/2024-06-04.md#rfc-process-review). I didn't try to cover everything that was discussed, just tried to document the policy updates that would avoid a situation like #182 in the future.

We could make more updates, e.g. around what happens if the infra meeting discussion doesn't result in PR comments, what should be the relevant timeout. Another question we might want to tackle is documenting the policy for reverting (#187), but I thought I would start with what I didn't hear a clear objection on. 

I'll bring this up in the next WPT infra meeting, too.